### PR TITLE
Raise error in discrete interval data

### DIFF
--- a/src/kk/kk.rs
+++ b/src/kk/kk.rs
@@ -60,7 +60,7 @@ pub fn real2imag_helper(x: &Vec<f64>, y: &Vec<f64>, num: usize) -> f64 {
         if *xx == base {
             continue;
         }
-        result += base * yy / (xx * xx - base * base) * diff;
+        result -= base * yy / (xx * xx - base * base) * diff;
     }
 
     result
@@ -80,7 +80,7 @@ pub fn imag2real_helper(x: &Vec<f64>, y: &Vec<f64>, num: usize) -> f64 {
         if *xx == x[num] {
             continue;
         }
-        result -= xx * yy / (xx * xx - base * base) * diff;
+        result += xx * yy / (xx * xx - base * base) * diff;
     }
 
     result

--- a/src/kk/kk.rs
+++ b/src/kk/kk.rs
@@ -3,11 +3,19 @@ use std::thread;
 use std::f64::consts::PI;
 
 use pyo3::prelude::*;
+use pyo3::exceptions::PyValueError;
+
+use crate::kk::utils::has_same_interval;
 
 pub fn kk_transform<F>(x: Vec<f64>, y: Vec<f64>, f: F) -> PyResult<Vec<f64>>
     where F: Fn(&Vec<f64>, &Vec<f64>, usize) -> f64,
           F: Send + Copy + 'static
 {
+    // TODO: interpolate if has different intervals
+    if !has_same_interval(&x) {
+        return Err(PyValueError::new_err("x should have the same interval"));
+    }
+
     let thread_num = 16;
     let mut handles: Vec<thread::JoinHandle<()>> = Vec::new();
     let mut result: Arc<Vec<Mutex<f64>>> = Arc::new(

--- a/src/kk/mod.rs
+++ b/src/kk/mod.rs
@@ -1,1 +1,2 @@
 pub mod kk;
+mod utils;

--- a/src/kk/utils.rs
+++ b/src/kk/utils.rs
@@ -1,0 +1,60 @@
+pub fn has_same_interval(x: &Vec<f64>) -> bool {
+    let interval = x[1] - x[0];
+    if interval == 0.0 {
+        return false;
+    }
+
+    for i in 1..x.len() {
+        if (x[i] - x[i-1] - interval).abs() / interval > 1e-8{
+            return false;
+        }
+    }
+
+    true
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_check_same_interval() {
+        let mut same_interval: Vec<f64> = vec![0.0; 10];
+        for i in 0..same_interval.len() {
+            same_interval[i] = i as f64;
+        }
+
+        assert_eq!(has_same_interval(&same_interval), true);
+    }
+
+    #[test]
+    fn test_false_in_diff_interval() {
+        let mut different_interval = vec![0.0; 10];
+        for i in 0..different_interval.len() {
+            different_interval[i] = i as f64;
+        }
+        different_interval[5] -= 1e-5;
+
+        assert_eq!(has_same_interval(&different_interval), false);
+    }
+
+    #[test]
+    fn test_same_element_vector_return_false() {
+        let different_interval = vec![0.0; 10];
+
+        assert_eq!(has_same_interval(&different_interval), false);
+    }
+
+    #[test]
+    fn allow_diff_smaller_than_one_in_a_million_percent() {
+        let mut same_interval = vec![0.0; 10];
+        for i in 0..same_interval.len() {
+            same_interval[i] = i as f64;
+        }
+
+        same_interval[5] -= 1e-8;
+
+        assert_eq!(has_same_interval(&same_interval), true);
+    }
+}


### PR DESCRIPTION
The Kramers-Kronig transform assumes the data has equal interval. If given data does not meet this requirement, the program should raise error.